### PR TITLE
update to 0.6.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "dagster_graphql" %}
-{% set version = "0.6.5" %}
+{% set version = "0.6.6" %}
+
+{% set dash_name = name.replace('_', '-') %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 420380da37e7acadf6f91177079812e04f76020e5c4dd1544966e84d8a08dba5
+  url: "https://pypi.io/packages/source/{{ dash_name[0] }}/{{ dash_name }}/{{ dash_name }}-{{ version }}.tar.gz"
+  sha256: d740b3ed0df5ff9919ac29804b034a932db2c720a6e01174d109796d6e3aed28
 
 build:
   number: 0


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- unblocks https://github.com/conda-forge/dagit-feedstock/pull/2

It appears the upstream filename changed.

Also, while looking over the repos, it looks like `dag(ster|git)*` are simultaneously released with the same version. Perhaps it makes sense to:
- move them all into one feedtock (`dagster`?)
- keep triggering the bot off the main `dagster` pypi tarball, as they make tags-per-push
- do all the builds from source. 

It's a big source tarball (they check in their yarn packages) but it should be much easier to keep everything consistent.